### PR TITLE
fixed base_tracker import

### DIFF
--- a/host/sphero_tracker.py
+++ b/host/sphero_tracker.py
@@ -6,7 +6,7 @@ import cv2
 import sys
 import constants
 import utilities
-from host.base_tracker import BaseTracker
+from base_tracker import BaseTracker
 
 from std_msgs.msg import Bool, Int16
 from sensor_msgs.msg import CompressedImage, Image


### PR DESCRIPTION
I removed the "host." portion before base_tracker, because you are already in the host folder, so this is redundant and it made you look for yet another nested host folder which did not exist.