### PR TITLE
changed default color to green

### DIFF
--- a/host/sphero_node.py
+++ b/host/sphero_node.py
@@ -19,7 +19,7 @@ class SpheroNode(object):
         self._connected = False
 
         if (self._color is None):
-            self._color = ColorRGBA(0, 0, 128,0)
+            self._color = ColorRGBA(0, 128, 0, 0)
         elif(self._color == "blue"):
             self._color = ColorRGBA(0, 0, 128, 0)
         elif (self._color == "red"):


### PR DESCRIPTION
I have no idea why this works, but we could not get our red agent to turn red. However, when we made the default color green, the script worked and turned our red agent red. To prove this, we switched the code back to the original, and we lost our red agent, and then we switched the code back to having the default green, and we regained our red agent.